### PR TITLE
use atomic std header

### DIFF
--- a/mecab/configure.ac
+++ b/mecab/configure.ac
@@ -2,6 +2,7 @@ dnl Process this file with autoconf to produce a configure script.
 AC_INIT([mecab], [0.996.1])
 AC_CONFIG_SRCDIR([src/mecab.cpp])
 AM_INIT_AUTOMAKE
+AH_TEMPLATE([HAVE_CXX11_ATOMIC_OPS], [])
 AH_TEMPLATE([HAVE_GCC_ATOMIC_OPS], [])
 AH_TEMPLATE([HAVE_OSX_ATOMIC_OPS], [])
 AH_TEMPLATE([HAVE_TLS_KEYWORD], [])
@@ -265,6 +266,24 @@ AC_TRY_COMPILE(
   config_error=yes
 ])
 AC_MSG_RESULT([$ac_template])
+
+AC_MSG_CHECKING([if ${CXX-c++} supports C++11 atomic operations (optional)])
+AC_TRY_COMPILE(
+[
+#include <thread>
+#include <atomic>
+],[
+  std::atomic<int> foo(0);
+  std::this_thread::yield();
+],[
+  enable_cxx11_atomic_ops=yes
+],[
+  enable_cxx11_atomic_ops=no
+])
+AC_MSG_RESULT([$enable_cxx11_atomic_ops])
+if test "$enable_cxx11_atomic_ops" = "yes"; then
+AC_DEFINE([HAVE_CXX11_ATOMIC_OPS])
+fi
 
 AC_MSG_CHECKING([if ${CXX-c++} supports GCC native atomic operations (optional)])
 AC_TRY_COMPILE(

--- a/mecab/src/thread.h
+++ b/mecab/src/thread.h
@@ -112,7 +112,7 @@ inline void yield_processor(void) {
 class atomic_int {
   public:
     atomic_int(): val_(0) {}
-    atomic_int(int init): val_(int) {}
+    atomic_int(int init): val_(init) {}
     int add(int a) {
       long ret = ::InterlockedExchangeAdd(&val_, static_cast<long>(a));
       return static_cast<int>(ret);


### PR DESCRIPTION
to fix the following warnings.

```
warning: 'OSAtomicAdd32' is deprecated: first deprecated in macOS 10.12 - Use std::atomic_fetch_add_explicit(std::memory_order_relaxed) from <atomic> instead [-Wdeprecated-declarations]
warning: 'OSAtomicCompareAndSwapInt' is deprecated: first deprecated in macOS 10.12 - Use std::atomic_compare_exchange_strong_explicit(std::memory_order_relaxed) from <atomic> instead [-Wdeprecated-declarations]
```