### PR TITLE
fix: warning: adding 'const char' to a string does not append to the …

### DIFF
--- a/mecab/src/writer.cpp
+++ b/mecab/src/writer.cpp
@@ -252,7 +252,8 @@ bool Writer::writeNode(Lattice *lattice,
       case '%': {  // macros
         switch (*++p) {
           default: {
-            const std::string error = "unknown meta char: " + *p;
+            std::string error = "unknown meta char: ";
+            error += *p;
             lattice->set_what(error.c_str());
             return false;
           }


### PR DESCRIPTION
…string [-Wstring-plus-int]

https://github.com/shogo82148/mecab/runs/431774760?check_suite_focus=true#step:4:295

```
writer.cpp:255:61: warning: adding 'const char' to a string does not append to the string [-Wstring-plus-int]
            const std::string error = "unknown meta char: " + *p;
                                      ~~~~~~~~~~~~~~~~~~~~~~^~~~
writer.cpp:255:61: note: use array indexing to silence this warning
            const std::string error = "unknown meta char: " + *p;
                                                            ^
                                      &                     [   ]
```
