### PR TITLE
fix: warning: 'void* memset(void*, int, size_t)' clearing an object o…

### DIFF
--- a/mecab/src/char_property.cpp
+++ b/mecab/src/char_property.cpp
@@ -191,7 +191,6 @@ bool CharProperty::compile(const char *cfile,
           << "category " << key << " is already defined";
 
       CharInfo c;
-      std::memset(&c, 0, sizeof(c));
       c.invoke  = std::atoi(col[1]);
       c.group   = std::atoi(col[2]);
       c.length  = std::atoi(col[3]);


### PR DESCRIPTION
…f non-trivial type 'struct MeCab::CharInfo'