### PR TITLE
GitHub Actions: Deprecating set-env and add-path commands

### DIFF
--- a/.github/cygwin-shell.bat
+++ b/.github/cygwin-shell.bat
@@ -1,0 +1,2 @@
+for /f "usebackq delims=" %%a in (`C:\tools\cygwin\cygpath.exe %0`) do set FILE=%%a
+C:\tools\cygwin\bin.exe --noprofile --norc -e -o pipefail %FILE%

--- a/.github/cygwin-shell.bat
+++ b/.github/cygwin-shell.bat
@@ -1,2 +1,0 @@
-for /f "usebackq delims=" %%a in (`C:\tools\cygwin\cygpath.exe %0`) do set FILE=%%a
-C:\tools\cygwin\bin.exe --noprofile --norc -e -o pipefail %FILE%

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           ./autogen.sh
           ./configure
-        shell: C:\tools\cygwin\bin.exe --noprofile --norc -e -o pipefail {0}
+        shell: ${{ github.workspace }}\.github\cygwin-shell.bat {0}
         working-directory: mecab
       - name: make
         run: |
@@ -57,7 +57,7 @@ jobs:
           ./configure --with-charset=utf8
           make all
           make install
-        shell: C:\tools\cygwin\bin.exe --noprofile --norc -e -o pipefail {0}
+        shell: { 0 }
         working-directory: mecab-ipadic
       # - run: perl -V
       # - name: build and test perl binding

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -21,22 +21,20 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: actions/cache@v2
+        id: cache
         with:
           path: |
-            C:\Users\runneradmin\AppData\Local\Temp\chocolatey
-            C:\tools\cygwin\package
-          key: ${{ runner.os }}-cygwin-chocolatey-${{ matrix.os }}-${{ github.sha }}
+            C:\tools\cygwin
+          key: ${{ runner.os }}-cygwin-chocolatey-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-cygwin-chocolatey-${{ matrix.os }}-
             ${{ runner.os }}-cygwin-chocolatey-
-      - name: Install cygwin base packages with chocolatey
+      - name: Install cygwin packages
         run: |
           choco config get cacheLocation
           choco install --no-progress cygwin
-      - name: Install cygwin additional packages
-        run: |
           C:\tools\cygwin\cygwinsetup.exe -qgnNdO -R C:/tools/cygwin -s http://mirrors.kernel.org/sourceware/cygwin/ -P autoconf,bison,gcc-g++,make,libtool,m4,aclocal,automake,libiconv-devel,gettext-devel,libcrypt-devel
         shell: cmd
+        if: steps.cache.outputs.cache-hit != 'true'
       - name: set PATH
         run: |
           echo "C:\tools\cygwin\usr\local\bin" >> "$GITHUB_PATH"

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -49,7 +49,7 @@ jobs:
           make all
           make check
           make install
-        shell: C:\tools\cygwin\bin.exe --noprofile --norc -e -o pipefail {0}
+        shell: C:\tools\cygwin\cygwin-shell.bat {0}
         working-directory: mecab
 
       - name: build ipadic
@@ -58,7 +58,7 @@ jobs:
           ./configure --with-charset=utf8
           make all
           make install
-        shell: { 0 }
+        shell: C:\tools\cygwin\cygwin-shell.bat {0}
         working-directory: mecab-ipadic
       # - run: perl -V
       # - name: build and test perl binding

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -36,29 +36,29 @@ jobs:
       - name: Install cygwin additional packages
         run: |
           C:\tools\cygwin\cygwinsetup.exe -qgnNdO -R C:/tools/cygwin -s http://mirrors.kernel.org/sourceware/cygwin/ -P autoconf,bison,gcc-g++,make,libtool,m4,aclocal,automake,libiconv-devel,gettext-devel,libcrypt-devel
-          copy .github\cygwin-shell.bat C:\tools\cygwin\cygwin-shell.bat
         shell: cmd
+      - name: set PATH
+        run: |
+          echo "C:\tools\cygwin\usr\local\bin" >> "$GITHUB_PATH"
+          echo "C:\tools\cygwin\bin" >> "$GITHUB_PATH"
+          echo "C:\tools\cygwin\usr\bin" >> "$GITHUB_PATH"
+        shell: bash
+
       - name: configure
         run: |
-          ./autogen.sh
-          ./configure
-        shell: C:\tools\cygwin\cygwin-shell.bat {0}
+          bash.exe -c "./autogen.sh; ./configure"
+        shell: cmd
         working-directory: mecab
       - name: make
         run: |
-          make all
-          make check
-          make install
-        shell: C:\tools\cygwin\cygwin-shell.bat {0}
+          bash -c "make all; make check; make install"
+        shell: cmd
         working-directory: mecab
 
       - name: build ipadic
         run: |
-          autogen.sh
-          ./configure --with-charset=utf8
-          make all
-          make install
-        shell: C:\tools\cygwin\cygwin-shell.bat {0}
+          bash -c "autogen.sh; ./configure --with-charset=utf8; make all; make install"
+        shell: cmd
         working-directory: mecab-ipadic
       # - run: perl -V
       # - name: build and test perl binding

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -36,12 +36,13 @@ jobs:
       - name: Install cygwin additional packages
         run: |
           C:\tools\cygwin\cygwinsetup.exe -qgnNdO -R C:/tools/cygwin -s http://mirrors.kernel.org/sourceware/cygwin/ -P autoconf,bison,gcc-g++,make,libtool,m4,aclocal,automake,libiconv-devel,gettext-devel,libcrypt-devel
+          copy .github\cygwin-shell.bat C:\tools\cygwin\cygwin-shell.bat
         shell: cmd
       - name: configure
         run: |
           ./autogen.sh
           ./configure
-        shell: ${{ github.workspace }}\.github\cygwin-shell.bat {0}
+        shell: C:\tools\cygwin\cygwin-shell.bat {0}
         working-directory: mecab
       - name: make
         run: |

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -20,9 +20,11 @@ jobs:
       - run: git config --global core.autoCRLF false
       - uses: actions/checkout@v2
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
-          path: C:\Users\runneradmin\AppData\Local\Temp\chocolatey
+          path: |
+            C:\Users\runneradmin\AppData\Local\Temp\chocolatey
+            C:\tools\cygwin\package
           key: ${{ runner.os }}-cygwin-chocolatey-${{ matrix.os }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-cygwin-chocolatey-${{ matrix.os }}-
@@ -31,40 +33,31 @@ jobs:
         run: |
           choco config get cacheLocation
           choco install --no-progress cygwin
-      - uses: actions/cache@v1
-        with:
-          path: C:\tools\cygwin\package
-          key: ${{ runner.os }}-cygwin-package-${{ matrix.os }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-cygwin-package-${{ matrix.os }}-
-            ${{ runner.os }}-cygwin-package-
       - name: Install cygwin additional packages
         run: |
           C:\tools\cygwin\cygwinsetup.exe -qgnNdO -R C:/tools/cygwin -s http://mirrors.kernel.org/sourceware/cygwin/ -P autoconf,bison,gcc-g++,make,libtool,m4,aclocal,automake,libiconv-devel,gettext-devel,libcrypt-devel
         shell: cmd
-      - name: Set ENV
-        run: |
-          echo '::set-env name=PATH::C:\tools\cygwin\usr\local\bin;C:\tools\cygwin\bin;C:\tools\cygwin\usr\bin'
       - name: configure
         run: |
-          bash.exe -c ./autogen.sh
-          bash.exe -c ./configure
-        shell: cmd
+          ./autogen.sh
+          ./configure
+        shell: C:\tools\cygwin\bin.exe --noprofile --norc -e -o pipefail {0}
         working-directory: mecab
       - name: make
         run: |
           make all
           make check
           make install
-        shell: cmd
+        shell: C:\tools\cygwin\bin.exe --noprofile --norc -e -o pipefail {0}
         working-directory: mecab
 
       - name: build ipadic
         run: |
-          bash.exe -c ./autogen.sh
-          bash.exe -c "./configure --with-charset=utf8"
+          autogen.sh
+          ./configure --with-charset=utf8
           make all
           make install
+        shell: C:\tools\cygwin\bin.exe --noprofile --norc -e -o pipefail {0}
         working-directory: mecab-ipadic
       # - run: perl -V
       # - name: build and test perl binding

--- a/.github/workflows/test-cygwin.yml
+++ b/.github/workflows/test-cygwin.yml
@@ -30,7 +30,6 @@ jobs:
             ${{ runner.os }}-cygwin-chocolatey-
       - name: Install cygwin packages
         run: |
-          choco config get cacheLocation
           choco install --no-progress cygwin
           C:\tools\cygwin\cygwinsetup.exe -qgnNdO -R C:/tools/cygwin -s http://mirrors.kernel.org/sourceware/cygwin/ -P autoconf,bison,gcc-g++,make,libtool,m4,aclocal,automake,libiconv-devel,gettext-devel,libcrypt-devel
         shell: cmd

--- a/.github/workflows/test-mingw.yml
+++ b/.github/workflows/test-mingw.yml
@@ -23,7 +23,11 @@ jobs:
           # MSYS2 is pre-installed from https://github.com/actions/virtual-environments/releases/tag/win19%2F20200608.1
           # but not added to PATH.
           # so, we need to add it to PATH here.
-          echo '::set-env name=PATH::C:\msys64;C:\msys64\bin;C:\msys64\usr\bin;C:\msys64\mingw64\bin;'
+          echo 'C:\msys64;' >> "$GITHUB_PATH"
+          echo 'C:\msys64\bin' >> "$GITHUB_PATH"
+          echo 'C:\msys64\usr\bin' >> "$GITHUB_PATH"
+          echo 'C:\msys64\mingw64\bin' >> "$GITHUB_PATH"
+        shell: bash
       - name: setup MSYS2
         run: |
           msys2_shell.cmd -c "pacman-key --init"


### PR DESCRIPTION
ref. https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

and some improvements of GitHub Actions Workflow.