### PR TITLE
 highest supported C++ standard and use thread_local

### DIFF
--- a/mecab/configure.ac
+++ b/mecab/configure.ac
@@ -6,6 +6,7 @@ AH_TEMPLATE([HAVE_CXX11_ATOMIC_OPS], [])
 AH_TEMPLATE([HAVE_GCC_ATOMIC_OPS], [])
 AH_TEMPLATE([HAVE_OSX_ATOMIC_OPS], [])
 AH_TEMPLATE([HAVE_TLS_KEYWORD], [])
+AH_TEMPLATE([HAVE_CXX11_TLS_KEYWORD], [])
 AC_CONFIG_MACRO_DIR([m4])
 
 MECAB_DESCRIPTION='MeCab @shogo82148 flavored: Yet Another Part-of-Speech and Morphological Analyzer'
@@ -60,7 +61,23 @@ AC_CHECK_LIB(pthread,pthread_create)
 AC_CHECK_LIB(pthread,pthread_join)
 AC_CHECK_FUNCS(getenv)
 AC_CHECK_FUNCS(opendir)
+
+dnl Checks for highest supported C++ standard
+dnl https://github.com/wikimedia/operations-debs-contenttranslation-apertium-lex-tools/blob/468f283d356c412d15e4c0d8bd42440e603b3d71/configure.ac#L71-L85
 AC_LANG(C++)
+AX_CHECK_COMPILE_FLAG([-std=c++20], [CXXFLAGS="$CXXFLAGS -std=c++20"], [
+ AX_CHECK_COMPILE_FLAG([-std=c++2a], [CXXFLAGS="$CXXFLAGS -std=c++2a"], [
+  AX_CHECK_COMPILE_FLAG([-std=c++17], [CXXFLAGS="$CXXFLAGS -std=c++17"], [
+   AX_CHECK_COMPILE_FLAG([-std=c++1z], [CXXFLAGS="$CXXFLAGS -std=c++1z"], [
+    AX_CHECK_COMPILE_FLAG([-std=c++14], [CXXFLAGS="$CXXFLAGS -std=c++14"], [
+     AX_CHECK_COMPILE_FLAG([-std=c++1y], [CXXFLAGS="$CXXFLAGS -std=c++1y"], [
+      AX_CHECK_COMPILE_FLAG([-std=c++11], [CXXFLAGS="$CXXFLAGS -std=c++11"], [])
+     ])
+    ])
+   ])
+  ])
+ ])
+])
 
 AC_ARG_ENABLE(utf8-only,
 [  --enable-utf8-only            use utf8 only [default no]])
@@ -99,12 +116,20 @@ else
 fi
 
 dnl
-dnl check gcc
+dnl check warning options
 dnl
-if test -n "$GCC"; then
-   CFLAGS="-O3 -Wall -Wextra"
-   CXXFLAGS="-O3 -Wall -Wextra"
-fi
+AX_CHECK_COMPILE_FLAG([-O3], [
+   CFLAGS="$CFLAGS -O3"
+  CXXFLAGS="$CXXFLAGS -O3"
+], [])
+AX_CHECK_COMPILE_FLAG([-Wall], [
+   CFLAGS="$CFLAGS -Wall"
+  CXXFLAGS="$CXXFLAGS -Wall"
+], [])
+AX_CHECK_COMPILE_FLAG([-Wextra], [
+   CFLAGS="$CFLAGS -Wextra"
+  CXXFLAGS="$CXXFLAGS -Wextra"
+], [])
 
 dnl
 dnl check Char Code
@@ -243,11 +268,32 @@ __thread int a = 0;
 ])
 AC_MSG_RESULT([$enable_tls])
 
-if test "$enable_tls" = "no"; then
-AC_MSG_WARN([__thread keyword is not supported on this environment. \
-Error handling of MeCab, e.g., MeCab::getLastError(), is not thread safe.])
-else
+if test "$enable_tls" = "yes"; then
 AC_DEFINE([HAVE_TLS_KEYWORD])
+fi
+
+dnl C++11 thread_local keyword
+AC_MSG_CHECKING([if ${CXX-c++} supports C++11 thread_local (optional)])
+AC_COMPILE_IFELSE(
+[AC_LANG_PROGRAM([[
+thread_local int a = 0;
+]],[[
+  a = 10;
+]])
+],[
+ enable_cxx11_tls=yes
+],[
+ enable_cxx11_tls=no
+])
+AC_MSG_RESULT([$enable_cxx11_tls])
+
+if test "$enable_cxx11_tls" = "yes"; then
+AC_DEFINE([HAVE_CXX11_TLS_KEYWORD])
+fi
+
+if test "$enable_tls$enable_cxx11_tls" = "nono"; then
+AC_MSG_WARN([thread_local and __thread keywords are not supported on this environment. \
+Error handling of MeCab, e.g., MeCab::getLastError(), is not thread safe.])
 fi
 
 AC_MSG_CHECKING([if ${CXX-c++} supports template <class T> (required)])

--- a/mecab/m4/ax_check_compile_flag.m4
+++ b/mecab/m4/ax_check_compile_flag.m4
@@ -1,0 +1,53 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS

--- a/mecab/src/char_property.h
+++ b/mecab/src/char_property.h
@@ -37,7 +37,7 @@ class CharProperty {
   inline const char *seekToOtherType(const char *begin, const char *end,
                                      CharInfo c, CharInfo *fail,
                                      size_t *mblen, size_t *clen) const {
-    register const char *p =  begin;
+    const char *p = begin;
     *clen = 0;
     while (p != end && c.isKindOf(*fail = getCharInfo(p, end, mblen))) {
       p += *mblen;

--- a/mecab/src/darts.h
+++ b/mecab/src/darts.h
@@ -404,10 +404,11 @@ class DoubleArrayImpl {
     T result;
     set_result(result, -1, 0);
 
-    register array_type_  b = array_[node_pos].base;
-    register array_u_type_ p;
+    array_type_ b = array_[node_pos].base;
+    array_u_type_ p;
 
-    for (register size_t i = 0; i < len; ++i) {
+    for (size_t i = 0; i < len; ++i)
+    {
       p = b +(node_u_type_)(key[i]) + 1;
       if (static_cast<array_u_type_>(b) == array_[p].check)
         b = array_[p].base;
@@ -431,12 +432,13 @@ class DoubleArrayImpl {
                             size_t node_pos = 0) const {
     if (!len) len = length_func_()(key);
 
-    register array_type_  b   = array_[node_pos].base;
-    register size_t     num = 0;
-    register array_type_  n;
-    register array_u_type_ p;
+    array_type_ b = array_[node_pos].base;
+    size_t num = 0;
+    array_type_ n;
+    array_u_type_ p;
 
-    for (register size_t i = 0; i < len; ++i) {
+    for (size_t i = 0; i < len; ++i)
+    {
       p = b;  // + 0;
       n = array_[p].base;
       if ((array_u_type_) b == array_[p].check && n < 0) {
@@ -469,8 +471,8 @@ class DoubleArrayImpl {
                       size_t len = 0) const {
     if (!len) len = length_func_()(key);
 
-    register array_type_  b = array_[node_pos].base;
-    register array_u_type_ p;
+    array_type_ b = array_[node_pos].base;
+    array_u_type_ p;
 
     for (; key_pos < len; ++key_pos) {
       p = b +(node_u_type_)(key[key_pos]) + 1;

--- a/mecab/src/libmecab.cpp
+++ b/mecab/src/libmecab.cpp
@@ -22,23 +22,6 @@ namespace {
 const size_t kErrorBufferSize = 256;
 }
 
-#if defined(HAVE_CXX11_TLS_KEYWORD)
-// C++11 thread_local keyword
-thread_local char kErrorBuffer[kErrorBufferSize];
-
-const char *getGlobalError()
-{
-  return kErrorBuffer;
-}
-
-void setGlobalError(const char *str)
-{
-  strncpy(kErrorBuffer, str, kErrorBufferSize - 1);
-  kErrorBuffer[kErrorBufferSize - 1] = '\0';
-}
-
-#else
-
 #if defined(_WIN32) && !defined(__CYGWIN__)
 namespace {
 const char kUnknownError[] = "Unknown Error";
@@ -99,16 +82,19 @@ extern "C" {
     return TRUE;
   }
 }
-#else  // _WIN32
+#else // _WIN32
 namespace {
-#ifdef HAVE_TLS_KEYWORD
-__thread char kErrorBuffer[kErrorBufferSize];
+#if defined(HAVE_CXX11_TLS_KEYWORD)
+  // C++11 thread_local keyword
+  thread_local char kErrorBuffer[kErrorBufferSize];
+#elif defined(HAVE_TLS_KEYWORD)
+  __thread char kErrorBuffer[kErrorBufferSize];
 #else
-char kErrorBuffer[kErrorBufferSize];
-#endif
-
+  char kErrorBuffer[kErrorBufferSize];
 #endif // HAVE_CXX11_TLS_KEYWORD
 }
+
+#endif
 
 const char *getGlobalError() {
   return kErrorBuffer;

--- a/mecab/src/libmecab.cpp
+++ b/mecab/src/libmecab.cpp
@@ -22,6 +22,23 @@ namespace {
 const size_t kErrorBufferSize = 256;
 }
 
+#if defined(HAVE_CXX11_TLS_KEYWORD)
+// C++11 thread_local keyword
+thread_local char kErrorBuffer[kErrorBufferSize];
+
+const char *getGlobalError()
+{
+  return kErrorBuffer;
+}
+
+void setGlobalError(const char *str)
+{
+  strncpy(kErrorBuffer, str, kErrorBufferSize - 1);
+  kErrorBuffer[kErrorBufferSize - 1] = '\0';
+}
+
+#else
+
 #if defined(_WIN32) && !defined(__CYGWIN__)
 namespace {
 const char kUnknownError[] = "Unknown Error";
@@ -89,6 +106,8 @@ __thread char kErrorBuffer[kErrorBufferSize];
 #else
 char kErrorBuffer[kErrorBufferSize];
 #endif
+
+#endif // HAVE_CXX11_TLS_KEYWORD
 }
 
 const char *getGlobalError() {

--- a/mecab/src/libmecab.cpp
+++ b/mecab/src/libmecab.cpp
@@ -94,8 +94,6 @@ namespace {
 #endif // HAVE_CXX11_TLS_KEYWORD
 }
 
-#endif
-
 const char *getGlobalError() {
   return kErrorBuffer;
 }

--- a/mecab/src/viterbi.cpp
+++ b/mecab/src/viterbi.cpp
@@ -319,11 +319,11 @@ template <bool IsAllPath> bool connect(size_t pos, Node *rnode,
                                        Allocator<Node, Path> *allocator) {
   (void)begin_node_list; // ignore unused parameter ‘begin_node_list’ [-Wunused-parameter]
   for (;rnode; rnode = rnode->bnext) {
-    register long best_cost = 2147483647;
+    long best_cost = 2147483647;
     Node* best_node = 0;
     for (Node *lnode = end_node_list[pos]; lnode; lnode = lnode->enext) {
-      register int lcost = connector->cost(lnode, rnode);  // local cost
-      register long cost = lnode->cost + lcost;
+      int lcost = connector->cost(lnode, rnode); // local cost
+      long cost = lnode->cost + lcost;
 
       if (cost < best_cost) {
         best_node  = lnode;


### PR DESCRIPTION
`__thread` keyword is a specific language enhancement of GCC.
There is no guarantee that it will work on other platforms.

`thread_local` is C++11 standardized version of `__thread`.
`thread_local` is more compatible than `__thread`.