### PR TITLE
migrate st-output command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
       - name: check mecab version
         id: mecab
         run: |
-          echo "::set-output name=version::$(cat mecab-version.txt)"
+          echo "version=$(cat mecab-version.txt)" >> "$GITHUB_OUTPUT"
         shell: bash
         working-directory: dist
       - name: untar mecab


### PR DESCRIPTION
see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/