### PR TITLE
add Perl 5.36, Python 3.11 and Ruby 3.2 on darwin

### DIFF
--- a/.github/workflows/test-darwin-perl.yml
+++ b/.github/workflows/test-darwin-perl.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         perl:
+          - "5.36"
           - "5.34"
           - "5.32"
           - "5.30"

--- a/.github/workflows/test-darwin-python.yml
+++ b/.github/workflows/test-darwin-python.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
+          - "3.11"
           - "3.10"
           - "3.9"
           - "3.8"

--- a/.github/workflows/test-darwin-ruby.yml
+++ b/.github/workflows/test-darwin-ruby.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "3.2"
           - "3.1"
           - "3.0"
           - "2.7"


### PR DESCRIPTION
Perl 5.36, Python 3.11 and Ruby 3.2 リリースにともなう対応に漏れがありました。