### PR TITLE
pyproject.tomlの導入

### DIFF
--- a/mecab/python/pyproject.toml
+++ b/mecab/python/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
主に`setup.py`自体の依存を記述するための設定ファイルだそうです。

https://tech.515hikaru.net/post/2019-11-23-pyproject/
https://towardsdatascience.com/pyproject-python-9df8cc092f61

`setuptools`に依存していることを明示的に設定します。