### PR TITLE
sprintfをsnprintfに置き換え

### DIFF
--- a/mecab/src/common.h
+++ b/mecab/src/common.h
@@ -20,11 +20,20 @@
 #include "config.h"
 #endif
 
-#if defined(_MSC_VER) || defined(__CYGWIN__)
+#if defined(_MSC_VER)
 #ifndef NOMINMAX
 #define NOMINMAX 1
 #endif
-#define snprintf _snprintf
+# if _MSC_VER < 1900
+#  define snprintf _snprintf
+# endif
+#include <iterator>
+#endif
+
+#if defined(__CYGWIN__)
+#ifndef NOMINMAX
+#define NOMINMAX 1
+#endif
 #include <iterator>
 #endif
 

--- a/mecab/src/eval.cpp
+++ b/mecab/src/eval.cpp
@@ -75,7 +75,7 @@ class Eval {
     double re = (r == 0) ? 0 : 100.0 * c/r;
     double F = ((pr + re) == 0.0) ? 0 : 2 * pr * re /(pr + re);
     scoped_fixed_array<char, BUF_SIZE> buf;
-    std::snprintf(buf.get(), buf.size(), "%4.4f(%d/%d) %4.4f(%d/%d) %4.4f\n",
+    snprintf(buf.get(), buf.size(), "%4.4f(%d/%d) %4.4f(%d/%d) %4.4f\n",
             pr,
             static_cast<int>(c),
             static_cast<int>(p),

--- a/mecab/src/eval.cpp
+++ b/mecab/src/eval.cpp
@@ -75,7 +75,7 @@ class Eval {
     double re = (r == 0) ? 0 : 100.0 * c/r;
     double F = ((pr + re) == 0.0) ? 0 : 2 * pr * re /(pr + re);
     scoped_fixed_array<char, BUF_SIZE> buf;
-    sprintf(buf.get(), "%4.4f(%d/%d) %4.4f(%d/%d) %4.4f\n",
+    std::snprintf(buf.get(), buf.size(), "%4.4f(%d/%d) %4.4f(%d/%d) %4.4f\n",
             pr,
             static_cast<int>(c),
             static_cast<int>(p),

--- a/mecab/src/string_buffer.h
+++ b/mecab/src/string_buffer.h
@@ -14,7 +14,7 @@ namespace MeCab {
 
 #define _ITOA(n)  do { char fbuf[64]; itoa(n, fbuf); return this->write(fbuf); } while (0)
 #define _UITOA(n) do { char fbuf[64]; uitoa(n, fbuf); return this->write(fbuf);} while (0)
-#define _DTOA(n)  do { char fbuf[64]; dtoa(n, fbuf); return this->write(fbuf); } while (0)
+#define _DTOA(n)  do { char fbuf[64]; dtoa(n, fbuf, sizeof(fbuf)); return this->write(fbuf); } while (0)
 
 class StringBuffer {
  private:

--- a/mecab/src/utils.h
+++ b/mecab/src/utils.h
@@ -44,7 +44,7 @@ enum { EUC_JP, CP932, UTF8, UTF16, UTF16LE, UTF16BE, ASCII };
 int decode_charset(const char *charset);
 
 void inline dtoa(double val, char *s, size_t n) {
-  std::snprintf(s, n, "%-16f", val);
+  snprintf(s, n, "%-16f", val);
   char *p = s;
   for (; *p != ' '; ++p) {}
   *p = '\0';

--- a/mecab/src/utils.h
+++ b/mecab/src/utils.h
@@ -43,8 +43,8 @@ class Param;
 enum { EUC_JP, CP932, UTF8, UTF16, UTF16LE, UTF16BE, ASCII };
 int decode_charset(const char *charset);
 
-void inline dtoa(double val, char *s) {
-  std::sprintf(s, "%-16f", val);
+void inline dtoa(double val, char *s, size_t n) {
+  std::snprintf(s, n, "%-16f", val);
   char *p = s;
   for (; *p != ' '; ++p) {}
   *p = '\0';


### PR DESCRIPTION
警告が出ていたので修正

```
./utils.h:47:8: warning: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Wdeprecated-declarations]
  std::sprintf(s, "%-16f", val);
```