### PR TITLE
prepare for releasing v0.999.10

### DIFF
--- a/mecab/content/_index.md
+++ b/mecab/content/_index.md
@@ -87,6 +87,9 @@ MeCab に至るまでの形態素解析器開発の歴史等は[こちら]({{<re
 
 ## 新着情報 {#news}
 
+- **2024-01-15** MeCab 0.996.10
+  - [Python wheel のビルドエラーを修正](https://github.com/shogo82148/mecab/pull/105)
+  - [SWIG 4.2.0 へアップデート](https://github.com/shogo82148/mecab/pull/112)
 - **2023-11-25** MeCab 0.996.9
   - [C++11で非推奨,C++17で削除された `std::binary_function` を削除](https://github.com/shogo82148/mecab/pull/102)
   - [Python 3.12, 3.11, 3.10, 3.9 向けの wheel 追加、Python 3.7, 3.6向けの wheelを削除](https://github.com/shogo82148/mecab/pull/101)
@@ -211,34 +214,34 @@ MeCab に至るまでの形態素解析器開発の歴史等は[こちら]({{<re
 
 - **MeCab** はフリーソフトウェアです．[GPL v2](https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt)(the GNU General Public License Version 2.0), [LGPL](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)(Lesser GNU General Public License Version 2.1), または [三条項BSD](https://spdx.org/licenses/BSD-3-Clause.html) ライセンスに従って本ソフトウェアを使用,再配布することができます。 詳細は COPYING, GPL, LGPL, BSD各ファイルを参照して下さい．
 
-- [v0.996.9](https://github.com/shogo82148/mecab/releases/tag/v0.996.9)
+- [v0.996.10](https://github.com/shogo82148/mecab/releases/tag/v0.996.10)
 
 ### MeCab 本体
 
 - Source
-  - mecab-0.996.9.tar.gz: [ダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.9/mecab-0.996.9.tar.gz)
+  - mecab-0.996.10.tar.gz: [ダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.10/mecab-0.996.10.tar.gz)
   - 辞書は含まれていません. 動作には別途辞書が必要です。
 - Binary package for MS-Windows
-  - mecab-msvc-x64-0.996.9.zip: [64bit版ダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.9/mecab-msvc-x64-0.996.9.zip)
-  - mecab-msvc-x86-0.996.9.zip: [32bit版ダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.9/mecab-msvc-x86-0.996.9.zip)
+  - mecab-msvc-x64-0.996.10.zip: [64bit版ダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.10/mecab-msvc-x64-0.996.10.zip)
+  - mecab-msvc-x86-0.996.10.zip: [32bit版ダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.10/mecab-msvc-x86-0.996.10.zip)
   - Windows 版には コンパイル済みの IPA 辞書が含まれています
 
 ### MeCab 用の辞書
 
 - IPA 辞書
-  - IPA 辞書, IPAコーパス に基づき [CRF][CRF] でパラメータ推定した辞書です。 **(推奨)** [ダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.9/mecab-ipadic-2.7.0-20070801.tar.gz)
+  - IPA 辞書, IPAコーパス に基づき [CRF][CRF] でパラメータ推定した辞書です。 **(推奨)** [ダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.10/mecab-ipadic-2.7.0-20070801.tar.gz)
 - JUMAN 辞書
-  - JUMAN 辞書, 京都コーパスに基づき [CRF][CRF] でパラメータ推定した辞書です。 [ダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.9/mecab-jumandic-7.0-20130310.tar.gz)
+  - JUMAN 辞書, 京都コーパスに基づき [CRF][CRF] でパラメータ推定した辞書です。 [ダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.10/mecab-jumandic-7.0-20130310.tar.gz)
 - Unidic 辞書
   - Unidic 辞書, BCCWJコーパスに基づき CRF でパラーメータ推定した辞書です。[ダウンロード](https://clrd.ninjal.ac.jp/unidic/)
 
 ### perl/ruby/python/java バインディング
 
-- [Perlダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.9/mecab-perl-0.996.9.tar.gz)
-- [Rubyダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.9/mecab-ruby-0.996.9.tar.gz)
-- [Pythonダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.9/mecab-python-0.996.9.tar.gz)
+- [Perlダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.10/mecab-perl-0.996.10.tar.gz)
+- [Rubyダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.10/mecab-ruby-0.996.10.tar.gz)
+- [Pythonダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.10/mecab-python-0.996.10.tar.gz)
   - Windowsに関してはコンパイル済みのwheelもあります。
-- [Javaダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.9/mecab-java-0.996.9.tar.gz)
+- [Javaダウンロード](https://github.com/shogo82148/mecab/releases/download/v0.996.10/mecab-java-0.996.10.tar.gz)
 
 ## インストール {#install}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated release information and download links for MeCab 0.996.10.
	- Provided updated bindings information for Perl, Ruby, Python, and Java.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->