### PR TITLE
fix Java Builds

### DIFF
--- a/.github/workflows/test-darwin-java.yml
+++ b/.github/workflows/test-darwin-java.yml
@@ -27,6 +27,9 @@ jobs:
           - "11"
           - "17"
           - "21"
+        exclude:
+          - distribution: temurin
+            java: "8"
     steps:
       - uses: actions/checkout@v4
       - name: setup

--- a/.github/workflows/test-linux-java.yml
+++ b/.github/workflows/test-linux-java.yml
@@ -27,9 +27,6 @@ jobs:
           - "11"
           - "17"
           - "21"
-        exclude:
-          - distribution: temurin
-            java: "8"
     steps:
       - run: sudo apt-get install gettext
       - uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow configurations for Java testing:
    - Excluded `temurin` distribution with Java version `8` on Darwin.
    - Removed exclusion for `temurin` distribution with Java version `8` on Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->