### PR TITLE
add Ruby 3.4.0 to the build matrix

### DIFF
--- a/.github/workflows/test-darwin-ruby.yml
+++ b/.github/workflows/test-darwin-ruby.yml
@@ -21,6 +21,8 @@ jobs:
       matrix:
         include:
           - os: macos-latest
+            ruby: "3.4"
+          - os: macos-latest
             ruby: "3.3"
           - os: macos-latest
             ruby: "3.2"

--- a/.github/workflows/test-linux-ruby.yml
+++ b/.github/workflows/test-linux-ruby.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - "3.4"
           - "3.3"
           - "3.2"
           - "3.1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for Ruby 3.4 in the testing workflows for both macOS and Linux environments.
- **Bug Fixes**
	- Enhanced testing coverage by including an additional Ruby version in the testing matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->