### PR TITLE
Add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   release:
     types: [created]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -346,6 +347,7 @@ jobs:
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
+    if: github.event_name == 'workflow_dispatch'
     needs:
       - python
       - manylinux-amd64


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**  
  - Enabled a manual trigger for workflow execution.  
  - Updated the testing deployment process so that publishing to the test package repository now occurs only when initiated manually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->