### PR TITLE
Python 3.14 is released

### DIFF
--- a/.github/build-wheel-linux.sh
+++ b/.github/build-wheel-linux.sh
@@ -19,7 +19,7 @@ cd /
 tar xzvf "/mecab/dist/scripts/mecab-python-${MECAB_VERSION}.tar.gz"
 
 # Build the wheels
-for PYVER in cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313; do
+for PYVER in cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313 cp314-cp314; do
   "/opt/python/${PYVER}/bin/pip" wheel "/mecab-python-${MECAB_VERSION}" -w /mecab/wheels
 done
 

--- a/.github/build-wheel-macos.sh
+++ b/.github/build-wheel-macos.sh
@@ -65,6 +65,6 @@ tar xzvf "dist/scripts/mecab-python-$MECAB_VERSION.tar.gz"
   python -m pip install --upgrade setuptools wheel pip setuptools-scm
   python -m pip install cibuildwheel==2.23.0
 
-  export CIBW_BUILD="cp38-* cp39-* cp310-* cp311-* cp312-* cp313-*"
+  export CIBW_BUILD="cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
   python -m cibuildwheel --platform macos --archs x86_64,arm64,universal2 --output-dir ../dist
 )

--- a/.github/build-windows.bat
+++ b/.github/build-windows.bat
@@ -31,6 +31,8 @@ set PATH=%GITHUB_WORKSPACE%\dist\zip\;%PATH%
 cd %GITHUB_WORKSPACE%\dist\scripts
 copy %GITHUB_WORKSPACE%\dist\mecab\src\*.dll .
 if "%BUILD_TYPE%" == "x64" (
+    py -3.14-64 -m pip install -U setuptools wheel pip
+    py -3.14-64 -m pip wheel .
     py -3.13-64 -m pip install -U setuptools wheel pip
     py -3.13-64 -m pip wheel .
     py -3.12-64 -m pip install -U setuptools wheel pip
@@ -42,6 +44,8 @@ if "%BUILD_TYPE%" == "x64" (
     py -3.9-64 -m pip install -U setuptools wheel pip
     py -3.9-64 -m pip wheel .
 ) else if "%BUILD_TYPE%" == "x86" (
+    py -3.14-32 -m pip install -U setuptools wheel pip
+    py -3.14-32 -m pip wheel .
     py -3.13-32 -m pip install -U setuptools wheel pip
     py -3.13-32 -m pip wheel .
     py -3.12-32 -m pip install -U setuptools wheel pip

--- a/.github/workflows/test-darwin-python.yml
+++ b/.github/workflows/test-darwin-python.yml
@@ -21,6 +21,8 @@ jobs:
       matrix:
         include:
           - os: macos-latest
+            python: "3.14"
+          - os: macos-latest
             python: "3.13"
           - os: macos-latest
             python: "3.12"

--- a/.github/workflows/test-linux-python.yml
+++ b/.github/workflows/test-linux-python.yml
@@ -20,6 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         python:
+          - "3.14"
           - "3.13"
           - "3.12"
           - "3.11"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added official Python 3.14 support with prebuilt wheels for Linux, macOS, and Windows (x64 and x86), enabling seamless installation on the latest Python version.
- Tests
  - Expanded test matrix to include Python 3.14 on macOS and Linux, improving coverage and confidence on the newest Python release.
- Chores
  - Updated build scripts to produce Python 3.14 artifacts across platforms without altering existing build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->