### PR TITLE
Add Python 3.14 to the list of supported programming languages in pyp…

### DIFF
--- a/mecab/python/pyproject.toml
+++ b/mecab/python/pyproject.toml
@@ -25,5 +25,6 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Text Processing"
 ]


### PR DESCRIPTION
…roject.toml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated package metadata to declare compatibility with Python 3.14, improving discoverability and ensuring installers recognize support for the latest Python version. Users on Python 3.14 can install without compatibility warnings. No changes to runtime behavior, APIs, or dependencies. Existing supported Python versions remain unchanged, and the build system is unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->