### PR TITLE
drop wheels for Python 3.9

### DIFF
--- a/.github/build-wheel-linux.sh
+++ b/.github/build-wheel-linux.sh
@@ -19,7 +19,7 @@ cd /
 tar xzvf "/mecab/dist/scripts/mecab-python-${MECAB_VERSION}.tar.gz"
 
 # Build the wheels
-for PYVER in cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313 cp314-cp314; do
+for PYVER in cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313 cp314-cp314; do
   "/opt/python/${PYVER}/bin/pip" wheel "/mecab-python-${MECAB_VERSION}" -w /mecab/wheels
 done
 

--- a/.github/build-wheel-macos.sh
+++ b/.github/build-wheel-macos.sh
@@ -65,6 +65,6 @@ tar xzvf "dist/scripts/mecab-python-$MECAB_VERSION.tar.gz"
   python -m pip install --upgrade setuptools wheel pip setuptools-scm
   python -m pip install cibuildwheel==2.23.0
 
-  export CIBW_BUILD="cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*"
+  export CIBW_BUILD="cp310-* cp311-* cp312-* cp313-* cp314-*"
   python -m cibuildwheel --platform macos --archs x86_64,arm64,universal2 --output-dir ../dist
 )

--- a/.github/build-windows.bat
+++ b/.github/build-windows.bat
@@ -41,8 +41,6 @@ if "%BUILD_TYPE%" == "x64" (
     py -3.11-64 -m pip wheel .
     py -3.10-64 -m pip install -U setuptools wheel pip
     py -3.10-64 -m pip wheel .
-    py -3.9-64 -m pip install -U setuptools wheel pip
-    py -3.9-64 -m pip wheel .
 ) else if "%BUILD_TYPE%" == "x86" (
     py -3.14-32 -m pip install -U setuptools wheel pip
     py -3.14-32 -m pip wheel .
@@ -54,6 +52,4 @@ if "%BUILD_TYPE%" == "x64" (
     py -3.11-32 -m pip wheel .
     py -3.10-32 -m pip install -U setuptools wheel pip
     py -3.10-32 -m pip wheel .
-    py -3.9-32 -m pip install -U setuptools wheel pip
-    py -3.9-32 -m pip wheel .
 )

--- a/mecab/python/pyproject.toml
+++ b/mecab/python/pyproject.toml
@@ -19,8 +19,6 @@ classifiers = [
   "Operating System :: Microsoft :: Windows :: Windows 10",
   "Operating System :: MacOS :: MacOS X",
   "Operating System :: POSIX :: Linux",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configurations and package metadata to drop support for Python 3.8 and 3.9. The package now requires Python 3.10 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->