### PR TITLE
Fix finding AM_ICONV

### DIFF
--- a/mecab/autogen.sh
+++ b/mecab/autogen.sh
@@ -3,11 +3,35 @@
 echo "Running libtoolize ..."
 libtoolize --force --copy \
   || glibtoolize --force --copy # fallback for macOS
+
+echo "Searching for gettext/m4 ..."
+gettext_m4_dir=""
+for d in \
+  /usr/share/gettext/m4 \
+  /usr/local/share/gettext/m4 \
+  /opt/homebrew/share/gettext/m4 \
+  /usr/local/opt/gettext/share/gettext/m4 \
+  /opt/homebrew/opt/gettext/share/gettext/m4
+do
+  if [ -d "$d" ]; then
+    echo "Found gettext/m4 in $d"
+    gettext_m4_dir="$d"
+    break
+  fi
+done
+
 echo "Running aclocal ..."
-aclocal -I . -I /usr/share/gettext/m4
+set -- -I .
+[ -n "$gettext_m4_dir" ] && set -- "$@" -I "$gettext_m4_dir"
+aclocal "$@"
+
 echo "Running autoheader..."
 autoheader
+
 echo "Running automake ..."
 automake --add-missing --copy
+
 echo "Running autoconf ..."
-autoconf -i -f -I /usr/share/gettext/m4
+set -- -i -f
+[ -n "$gettext_m4_dir" ] && set -- "$@" -I "$gettext_m4_dir"
+autoconf "$@"

--- a/mecab/autogen.sh
+++ b/mecab/autogen.sh
@@ -4,10 +4,10 @@ echo "Running libtoolize ..."
 libtoolize --force --copy \
   || glibtoolize --force --copy # fallback for macOS
 echo "Running aclocal ..."
-aclocal -I .
+aclocal -I . -I /usr/share/gettext/m4
 echo "Running autoheader..."
 autoheader
 echo "Running automake ..."
 automake --add-missing --copy
 echo "Running autoconf ..."
-autoconf -i -f
+autoconf -i -f -I /usr/share/gettext/m4


### PR DESCRIPTION
Make `autogen.sh` check `/usr/share/gettext/m4` so that it can find `AM_ICONV`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced build generation script to detect and include standard gettext macro directories when running autotools.
  * Added the discovered include path to autotools invocations to improve macro resolution.
  * Added informative output showing the located include directory during the build step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->