### PR TITLE
use Visual Studio 2026

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -66,7 +66,7 @@ jobs:
       - name: build
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.machine }}
+          call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.machine }}
           nmake -f Makefile.msvc MACHINE=${{ matrix.machine }}
         working-directory: mecab/src
       - name: test


### PR DESCRIPTION
ref. https://github.com/actions/runner-images/issues/14017

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Windows CI build setup to use the Visual Studio 18 installation path for environment configuration before running `nmake`.
  * This ensures the build uses the intended Visual Studio toolchain during Windows builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->