### PR TITLE
Add Perl 5.42 and 5.44 to the test matrix for macOS and Linux workflows

### DIFF
--- a/.github/workflows/test-darwin-perl.yml
+++ b/.github/workflows/test-darwin-perl.yml
@@ -20,6 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         perl:
+          - "5.44"
+          - "5.42"
           - "5.40"
           - "5.38"
           - "5.36"

--- a/.github/workflows/test-linux-perl.yml
+++ b/.github/workflows/test-linux-perl.yml
@@ -20,6 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         perl:
+          - "5.44"
+          - "5.42"
           - "5.40"
           - "5.38"
           - "5.36"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded Perl compatibility testing across macOS and Linux.
  * Added coverage for Perl versions 5.42 and 5.44 in automated test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->